### PR TITLE
exclude /dev/null from extract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ rootfs:
 	@echo "### create rootfs directory in ./plugin/rootfs"
 	@mkdir -p ./plugin/rootfs
 	@docker create --name tmp ${PLUGIN_NAME}:rootfs
-	@docker export tmp | tar -x -C ./plugin/rootfs
+	@docker export tmp | tar -x -C ./plugin/rootfs --exclude dev/null
 	@echo "### copy config.json to ./plugin/"
 	@cp config.json ./plugin/
 	@docker rm -vf tmp


### PR DESCRIPTION
otherwise make rootfs fails with: 
```
dev/null: Can't create 'dev/null'
tar: Error exit delayed from previous errors.
make: *** [rootfs] Error 1
```